### PR TITLE
Snap: debug switching cameras beyond 2 (dual rear cameras)

### DIFF
--- a/src/com/android/camera/MenuController.java
+++ b/src/com/android/camera/MenuController.java
@@ -104,6 +104,7 @@ public class MenuController {
                 return;
             }
         }
+        index = index % ((IconListPreference) pref).getLargeIconIds().length;
         ((ImageView) switcher).setImageResource(pref.getLargeIconIds()[index]);
 
     }

--- a/src/com/android/camera/PhotoMenu.java
+++ b/src/com/android/camera/PhotoMenu.java
@@ -680,6 +680,7 @@ public class PhotoMenu extends MenuController
         int index = pref.findIndexOfValue(pref.getValue());
         if (!pref.getUseSingleIcon() && iconIds != null) {
             // Each entry has a corresponding icon.
+			index = index % iconIds.length;
             resid = iconIds[index];
         } else {
             // The preference only has a single icon to represent it.
@@ -707,8 +708,9 @@ public class PhotoMenu extends MenuController
                 CharSequence[] values = pref.getEntryValues();
                 index = (index + 1) % values.length;
                 pref.setValueIndex(index);
+                int iconListLength = ((IconListPreference) pref).getLargeIconIds().length;
                 ((ImageView) v).setImageResource(
-                        ((IconListPreference) pref).getLargeIconIds()[index]);
+                        ((IconListPreference) pref).getLargeIconIds()[index % iconListLength]);
                 if (prefKey.equals(CameraSettings.KEY_CAMERA_ID))
                     mListener.onCameraPickerClicked(index);
                 reloadPreference(pref);


### PR DESCRIPTION
With devices like LG G5 h850 with dual rear cameras, Snap may crash when switching between more than 2 cameras. A FATAL EXCEPTION java.lang.ArrayIndexOutOfBoundsException is thrown. This pull request avoids this. 

Please inform me how to improve the pull request if it can not be merged as is.
